### PR TITLE
Fixes for priority handling

### DIFF
--- a/journal_brief/constants.py
+++ b/journal_brief/constants.py
@@ -28,4 +28,4 @@ for attr in dir(journal):
         value = getattr(journal, attr)
         svalue = str(value)
         for key in [value, svalue, attr[4:].lower()]:
-            PRIORITY_MAP[key] = svalue
+            PRIORITY_MAP[key] = value

--- a/journal_brief/filter.py
+++ b/journal_brief/filter.py
@@ -56,22 +56,23 @@ class FilterRule(dict):
     def __init__(self, mapping):
         assert isinstance(mapping, dict)
 
-        # Make sure everything is interpreted as a string
-        str_mapping = {}
+        # Make sure everything is interpreted as the appropriate type
+        type_mapping = {}
         for field, matches in mapping.items():
+            converter = DEFAULT_CONVERTERS.get(field, str)
             if field == 'PRIORITY':
                 try:
                     level = int(PRIORITY_MAP[matches])
                 except (AttributeError, TypeError):
-                    str_mapping[field] = [PRIORITY_MAP[match]
-                                          for match in matches]
+                    type_mapping[field] = [converter(PRIORITY_MAP[match])
+                                           for match in matches]
                 else:
-                    str_mapping[field] = list(range(level + 1))
+                    type_mapping[field] = [converter(prio)
+                                           for prio in list(range(level + 1))]
             else:
-                converter = DEFAULT_CONVERTERS.get(field, str)
-                str_mapping[field] = [converter(match) for match in matches]
+                type_mapping[field] = [converter(match) for match in matches]
 
-        super(FilterRule, self).__init__(str_mapping)
+        super(FilterRule, self).__init__(type_mapping)
 
     def __str__(self):
         rdict = {}

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -109,7 +109,8 @@ class TestInclusion(object):
 
     def test_priority(self):
         inclusion = Inclusion({'PRIORITY': 'err'})
-        assert inclusion.matches({'PRIORITY': 3})
+        priority_type = journal.DEFAULT_CONVERTERS.get('PRIORITY', str)
+        assert inclusion.matches({'PRIORITY': priority_type(3)})
 
     def test_repr(self):
         incl = {'MESSAGE': ['include this']}
@@ -154,7 +155,8 @@ class TestExclusion(object):
 
     def test_priority(self):
         exclusion = Exclusion({'PRIORITY': 'err'})
-        assert exclusion.matches({'PRIORITY': 3})
+        priority_type = journal.DEFAULT_CONVERTERS.get('PRIORITY', str)
+        assert exclusion.matches({'PRIORITY': priority_type(3)})
 
     def test_str_without_comment(self):
         excl = {'MESSAGE': ['exclude this']}
@@ -216,10 +218,11 @@ class TestJournalFilter(object):
         assert lines == [entry['MESSAGE'] for entry in entries]
 
     def test_exclusion(self):
+        priority_type = journal.DEFAULT_CONVERTERS.get('PRIORITY', str)
         entries = [{'MESSAGE': 'exclude this',
                     'SYSLOG_IDENTIFIER': 'from here'},
 
-                   {'PRIORITY': '6',
+                   {'PRIORITY': priority_type(6),
                     'MESSAGE': 'exclude this too'},
 
                    {'MESSAGE': 'message 1',


### PR DESCRIPTION
Filters for PRIORITY need to be in the type that systemd.journal expects.

Fixes #39.