### PR TITLE
Add support for direct email of output

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,64 @@ output.
 To create exclusion rules, rather than showing journal entries, run
 `journal-brief --dry-run debrief`.
 
+## Email
+
+The standard behavior of journal-brief is to send the desired journal
+entries to the standard output, but if desired it can be configured to
+send them via email instead. To do this, add an `email` section to the
+configuration file. There are two ways that email can be sent: through
+a command which implements the normal `mail` interface, or directly
+via SMTP.
+
+### Configuration keys
+
+* `suppress_empty`: if true, no email will be sent unless matching journal
+entries are found (defaults to `true`)
+
+### Email via command
+
+Example:
+```yaml
+email:
+  command: "mail -s 'journal output' admin@example.com"
+```
+
+This will cause journal-brief to execute the specified command in a
+child process and pipe the formatted journal entries to it. The supplied
+command string will be executed via the shell (typically identified in the
+`SHELL` environment variable) so it can make use of shell expansions and
+other features.
+
+### Email via SMTP
+
+Example:
+```yaml
+email:
+  smtp:
+    from: "journal sender" <journal@example.com>
+    to: "system admin" <admin@example.com>
+```
+
+This will cause journal-brief to use the Python `smtplib` module to send
+the formatted output to `admin@example.com`.
+
+#### Email SMTP configuration keys
+
+* `from`: RFC-5322 format address to be used as the sender address (required)
+
+* `to`: RFC-5322 format address to be used as the recipient address (required)
+
+* `subject`: string to be used as the email message subject
+
+* `host`: hostname or address of the SMTP server to use for sending email
+(defaults to `localhost`)
+
+* `port`: port number to connect to on the SMTP server (defaults to `25`)
+
+* `starttls`: boolean value indicating whether STARTTLS should be used to
+secure the connection to the SMTP server
+
+* `user`: username to be used to authenticate to the SMTP server
+
+* `password`: password to be used to authenticate to the SMTP server (only
+used if `user` is specified)

--- a/journal_brief/cli/constants.py
+++ b/journal_brief/cli/constants.py
@@ -1,0 +1,20 @@
+"""
+Copyright (c) 2020 Tim Waugh <tim@cyberelk.net>
+
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, write to the Free Software
+## Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""
+
+EMAIL_SUPPRESS_EMPTY_TEXT = 'No matching entries found in journal.\n'
+EMAIL_DRY_RUN_SEPARATOR = '------'

--- a/journal_brief/cli/main.py
+++ b/journal_brief/cli/main.py
@@ -34,8 +34,8 @@ from journal_brief import (SelectiveReader,
                            get_formatter,
                            list_formatters,
                            JournalFilter)
-from journal_brief.cli.constants import EMAIL_SUPPRESS_EMPTY_TEXT
-from journal_brief.cli.constants import EMAIL_DRY_RUN_SEPARATOR
+from journal_brief.cli.constants import (EMAIL_SUPPRESS_EMPTY_TEXT,
+                                         EMAIL_DRY_RUN_SEPARATOR)
 from journal_brief.config import Config, ConfigError
 from journal_brief.constants import PACKAGE, CONFIG_DIR, PRIORITY_MAP
 import journal_brief.format.config   # registers class; # noqa: F401
@@ -211,7 +211,7 @@ class CLI(object):
     def send_email(self, output):
         email = self.config.get('email')
 
-        if len(output) == 0:
+        if not output:
             if not email['suppress_empty']:
                 output = EMAIL_SUPPRESS_EMPTY_TEXT
             else:

--- a/journal_brief/journal_brief.py
+++ b/journal_brief/journal_brief.py
@@ -181,6 +181,11 @@ class LatestJournalEntries(Iterator):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        # if an exception was thrown by the code using this
+        # context manager, don't update the cursor
+        if exc_type is not None:
+            return
+
         if self.dry_run:
             return
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -21,8 +21,8 @@ from email.mime.text import MIMEText
 from email import charset
 from flexmock import flexmock
 from tests.util import Watcher
-from journal_brief.cli.constants import EMAIL_SUPPRESS_EMPTY_TEXT
-from journal_brief.cli.constants import EMAIL_DRY_RUN_SEPARATOR
+from journal_brief.cli.constants import (EMAIL_SUPPRESS_EMPTY_TEXT,
+                                         EMAIL_DRY_RUN_SEPARATOR)
 from journal_brief.cli.main import CLI
 import json
 import logging

--- a/tests/missing/systemd/journal/__init__.py
+++ b/tests/missing/systemd/journal/__init__.py
@@ -55,6 +55,7 @@ class Reader(Iterator):
     def close(self):
         pass
 
+
 class Monotonic(object):
     def __init__(self, init_tuple):
         self.timestamp = init_tuple[0]


### PR DESCRIPTION
Adds an 'email' section to configuration, allowing the tool to directly
send the filtered/formatted output via 'smtplib', avoiding the need to
run the tool in a cron-type wrapper to capture the output.