### PR TITLE
Avoid exception on first run and no matching journal entries

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -41,6 +41,7 @@ def config_and_cursor(tmp_path):
             configfile.flush()
             yield (configfile, cursorfile)
 
+
 @pytest.fixture
 def missing_or_empty_cursor():
     (flexmock(journal.Reader)
@@ -49,6 +50,7 @@ def missing_or_empty_cursor():
     (flexmock(journal.Reader)
         .should_receive('get_previous')
         .and_return({'__CURSOR': '0'}))
+
 
 class TestCLI(object):
     def test_param_override(self):
@@ -137,7 +139,7 @@ class TestCLI(object):
 
     def test_reset(self, config_and_cursor):
         (configfile, cursorfile) = config_and_cursor
-        with cursorfile: # force the cursorfile context to be exited at the right time
+        with cursorfile:  # force the cursorfile context to be exited at the right time
             cli = CLI(args=['--conf', configfile.name, 'reset'])
             cli.run()
             # Cursor file is deleted

--- a/tests/missing/systemd/journal/__init__.py
+++ b/tests/missing/systemd/journal/__init__.py
@@ -22,7 +22,7 @@ class Reader(Iterator):
         raise RuntimeError
 
     def get_previous(self):
-        return {'__CURSOR': '0'}
+        raise RuntimeError
 
     def __next__(self):
         entry = self.get_next()
@@ -50,7 +50,7 @@ class Reader(Iterator):
         raise RuntimeError
 
     def seek_tail(self):
-        pass
+        raise RuntimeError
 
     def close(self):
         pass

--- a/tests/missing/systemd/journal/__init__.py
+++ b/tests/missing/systemd/journal/__init__.py
@@ -21,6 +21,9 @@ class Reader(Iterator):
     def get_next(self):
         raise RuntimeError
 
+    def get_previous(self):
+        return {'__CURSOR': '0'}
+
     def __next__(self):
         entry = self.get_next()
         if not entry:
@@ -46,6 +49,11 @@ class Reader(Iterator):
     def seek_cursor(self, cursor):
         raise RuntimeError
 
+    def seek_tail(self):
+        pass
+
+    def close(self):
+        pass
 
 class Monotonic(object):
     def __init__(self, init_tuple):

--- a/tests/test_journal_brief.py
+++ b/tests/test_journal_brief.py
@@ -127,10 +127,12 @@ class TestSelectiveReader(object):
 def cursor_file_path(tmp_path):
     return os.path.join(str(tmp_path), 'cursor')
 
+
 @pytest.fixture
 def cursor_file(cursor_file_path):
     with open(cursor_file_path, 'w+t') as fp:
         yield fp
+
 
 @pytest.fixture
 def missing_or_empty_cursor():
@@ -140,6 +142,7 @@ def missing_or_empty_cursor():
     (flexmock(journal.Reader)
         .should_receive('get_previous')
         .and_return({'__CURSOR': '0'}))
+
 
 class TestLatestJournalEntries(object):
     def test_without_cursor(self, cursor_file_path, missing_or_empty_cursor):


### PR DESCRIPTION
When there is no existing cursor file, and the inclusions/exclusions result
in zero matching entries, an exception would be thrown because there was no
cursor value to write to the cursor file at the end of the run. To avoid this,
the cursor for the 'tail' of the journal is now obtained when there is no
cursor file to use as a starting point, and if no matching entries are found
that cursor will be written to the cursor file, which avoids the exception
and also avoids scanning the same journal entries that did not match during
the next run.

Closes #47.