### PR TITLE
Correct testing and sending of SMTP mail

### DIFF
--- a/journal_brief/cli/main.py
+++ b/journal_brief/cli/main.py
@@ -245,7 +245,7 @@ class CLI(object):
                         sender.starttls(context=ssl.create_default_context())
                     if 'user' in smtp:
                         sender.login(smtp.get('user'), smtp.get('password'))
-                    sender.send_message(str(message))
+                    sender.send_message(message)
 
     def run(self):
         if self.handle_options():

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -522,6 +522,14 @@ class TestCLIEmailCommand(object):
         cli.run()
 
 
+class EmailMessageMatcher(object):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __eq__(self, msg):
+        return str(self.msg) == str(msg)
+
+
 class TestCLIEmailSMTP(object):
     TEST_USER = 'zork'
     TEST_PASSWORD = 'xyzzy'
@@ -548,7 +556,7 @@ class TestCLIEmailSMTP(object):
 
         (flexmock(smtplib.SMTP)
          .should_receive('send_message')
-         .with_args(str(message))
+         .with_args(EmailMessageMatcher(message))
          .once())
 
         (configfile, cursorfile) = config_and_cursor
@@ -614,7 +622,7 @@ class TestCLIEmailSMTP(object):
 
         (flexmock(smtplib.SMTP)
          .should_receive('send_message')
-         .with_args(str(message))
+         .with_args(EmailMessageMatcher(message))
          .once())
 
         (configfile, cursorfile) = config_and_cursor
@@ -819,7 +827,7 @@ class TestCLIEmailSMTP(object):
 
         (flexmock(smtplib.SMTP)
          .should_receive('send_message')
-         .with_args(str(message))
+         .with_args(EmailMessageMatcher(message))
          .once())
 
         (configfile, cursorfile) = config_and_cursor


### PR DESCRIPTION
An error was made when modifying `send_email` to supply the message
argument as a string (which made mock testing easier). `send_message`
requires the argument as an object, but if the message is passed as
an object then a simple equality comparison in the mock tester
will fail.

A custom matcher has been added to compare the message objects as
strings instead, so that the proper argument type can be passed to
`send_message`.