### PR TITLE
Use unittest.mock (via pytest-mock) for email unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.8"
 install:
   - pip install PyYAML
-  - pip install flexmock
+  - pip install flexmock pytest-mock
   - pip install pytest-cov coveralls
   - pip install -r tests/requirements.txt
 script: py.test -vv -rs tests --cov journal_brief --benchmark-skip

--- a/journal_brief/cli/main.py
+++ b/journal_brief/cli/main.py
@@ -24,7 +24,7 @@ from locale import setlocale, LC_ALL
 import logging
 import os
 import signal
-import smtplib
+from smtplib import SMTP
 import ssl
 import subprocess
 import sys
@@ -240,7 +240,7 @@ class CLI(object):
                 print(EMAIL_DRY_RUN_SEPARATOR)
                 print(message)
             else:
-                with smtplib.SMTP(smtp.get('host'), smtp.get('port', 0)) as sender:
+                with SMTP(smtp.get('host'), smtp.get('port', 0)) as sender:
                     if smtp.get('starttls', False):
                         sender.starttls(context=ssl.create_default_context())
                     if 'user' in smtp:

--- a/python-journal-brief.spec
+++ b/python-journal-brief.spec
@@ -12,7 +12,7 @@ Source0:	https://pypi.python.org/packages/source/j/%{srcname}/%{srcname}-%{versi
 
 BuildArch:	noarch
 BuildRequires:	python3-devel
-BuildRequires:	python3-pytest python3-flexmock
+BuildRequires:	python3-pytest python3-flexmock python3-pytest-mock
 BuildRequires:	python3-PyYAML
 
 %description

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'console_scripts': ['journal-brief=journal_brief.cli.main:run'],
     },
     install_requires=['PyYAML', 'systemd-python'],
-    tests_require=['pytest', 'flexmock'],
+    tests_require=['pytest', 'flexmock', 'pytest-mock'],
     cmdclass={'test': PyTest},
     packages=find_packages(exclude=['tests',
                                     'tests.cli',


### PR DESCRIPTION
unittest.mock provides full mocks, with type checking, and simplifies mocking chains of objects. This capability allows the SMTP email tests to avoid depending on the behavior of the MIMEText and SMTP classes, instead only ensuring that those classes are properly used. The type checking support could have caught two recent bugs.
