### PR TITLE
Additional SMTP email features

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,14 @@ the formatted output to `admin@example.com`.
 
 * `from`: RFC-5322 format address to be used as the sender address (required)
 
-* `to`: RFC-5322 format address to be used as the recipient address (required)
+* `to`: RFC-5322 format address to be used as the recipient address, or a list
+of such addresses (required)
+
+* `cc`: RFC-5322 format address to be used as a carbon-copy address,
+or a list of such addresses
+
+* `bcc`: RFC-5322 format address to be used as a blind-carbon-copy address,
+or a list of such addresses
 
 * `subject`: string to be used as the email message subject
 
@@ -207,3 +214,6 @@ secure the connection to the SMTP server
 
 * `password`: password to be used to authenticate to the SMTP server (only
 used if `user` is specified)
+
+* 'headers': dictionary of string keys and string values to be added as
+custom headers; the dictionary cannot include 'From', 'To', 'Cc', or 'Bcc'

--- a/journal_brief/cli/main.py
+++ b/journal_brief/cli/main.py
@@ -33,7 +33,8 @@ from journal_brief import (SelectiveReader,
                            LatestJournalEntries,
                            get_formatter,
                            list_formatters,
-                           JournalFilter)
+                           JournalFilter,
+                           __version__ as journal_brief_version)
 from journal_brief.cli.constants import (EMAIL_SUPPRESS_EMPTY_TEXT,
                                          EMAIL_DRY_RUN_SEPARATOR)
 from journal_brief.config import Config, ConfigError
@@ -228,10 +229,18 @@ class CLI(object):
             smtp = email['smtp']
             charset.add_charset('utf-8', charset.QP, charset.QP)
             message = MIMEText(output, _charset='utf-8')
+            message['X-Journal-Brief-Version'] = journal_brief_version
             message['From'] = smtp['from']
-            message['To'] = smtp['to']
+            message['To'] = ', '.join(smtp['to'])
             if 'subject' in smtp:
                 message['Subject'] = smtp['subject']
+            if 'cc' in smtp:
+                message['Cc'] = ', '.join(smtp['cc'])
+            if 'bcc' in smtp:
+                message['Bcc'] = ', '.join(smtp['bcc'])
+            if 'headers' in smtp:
+                for header, value in smtp['headers'].items():
+                    message[header] = value
 
             if self.args.dry_run:
                 print("Email to be delivered via SMTP to {0} port {1}".format(

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -714,3 +714,70 @@ class TestCLIEmailSMTP(TestCLIEmailBase):
         cli.run()
 
         self.mimetext_object.__setitem__.assert_any_call('Subject', self.TEST_SUBJECT)
+
+    def test_to_list(self, build_config_and_cursor):
+        (configfile, cursorfile) = build_config_and_cursor({
+            'email': {
+                'suppress_empty': False,
+                'smtp': {
+                    'from': 'F',
+                    'to': ['A', 'B'],
+                },
+            },
+        })
+        cli = CLI(args=['--conf', configfile.name])
+        cli.run()
+
+        self.mimetext_object.__setitem__.assert_any_call('To', 'A, B')
+
+    def test_cc_list(self, build_config_and_cursor):
+        (configfile, cursorfile) = build_config_and_cursor({
+            'email': {
+                'suppress_empty': False,
+                'smtp': {
+                    'from': 'F',
+                    'to': 'T',
+                    'cc': ['A', 'B'],
+                },
+            },
+        })
+        cli = CLI(args=['--conf', configfile.name])
+        cli.run()
+
+        self.mimetext_object.__setitem__.assert_any_call('Cc', 'A, B')
+
+    def test_bcc_list(self, build_config_and_cursor):
+        (configfile, cursorfile) = build_config_and_cursor({
+            'email': {
+                'suppress_empty': False,
+                'smtp': {
+                    'from': 'F',
+                    'to': 'T',
+                    'bcc': ['A', 'B'],
+                },
+            },
+        })
+        cli = CLI(args=['--conf', configfile.name])
+        cli.run()
+
+        self.mimetext_object.__setitem__.assert_any_call('Bcc', 'A, B')
+
+    def test_headers(self, build_config_and_cursor):
+        (configfile, cursorfile) = build_config_and_cursor({
+            'email': {
+                'suppress_empty': False,
+                'smtp': {
+                    'from': 'F',
+                    'to': 'T',
+                    'headers': {
+                        'X-Header-1': '1',
+                        'X-Header-4': '4',
+                    },
+                },
+            },
+        })
+        cli = CLI(args=['--conf', configfile.name])
+        cli.run()
+
+        self.mimetext_object.__setitem__.assert_any_call('X-Header-1', '1')
+        self.mimetext_object.__setitem__.assert_any_call('X-Header-4', '4')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -199,6 +199,86 @@ exclusions:
             'to': 'bar',
             'password': [],
         }},
+        {'smtp': {
+            'from': 'foo',
+            'to': {},
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'cc': {},
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'bcc': {},
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': [],
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': 'baz',
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'From': 'foo',
+            },
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'To': 'foo',
+            },
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'Cc': 'foo',
+            },
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'Bcc': 'foo',
+            },
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'from': 'foo',
+            },
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'TO': 'foo',
+            },
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'cC': 'foo',
+            },
+        }},
+        {'smtp': {
+            'from': 'foo',
+            'to': 'bar',
+            'headers': {
+                'BcC': 'foo',
+            },
+        }},
     ])
     def test_validation_email(self, badconfig):
         with NamedTemporaryFile(mode='wt') as cfp:


### PR DESCRIPTION
* 'to' can now accept a list of addresses

* 'cc' and 'bcc' added with their usual meanings

* 'headers' can provide a list of custom headers

* 'X-Journal-Brief-Version' header always added