### PR TITLE
Use MIME-formatted email for both delivery modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,35 +160,6 @@ via SMTP.
 * `suppress_empty`: if true, no email will be sent unless matching journal
 entries are found (defaults to `true`)
 
-### Email via command
-
-Example:
-```yaml
-email:
-  command: "mail -s 'journal output' admin@example.com"
-```
-
-This will cause journal-brief to execute the specified command in a
-child process and pipe the formatted journal entries to it. The supplied
-command string will be executed via the shell (typically identified in the
-`SHELL` environment variable) so it can make use of shell expansions and
-other features.
-
-### Email via SMTP
-
-Example:
-```yaml
-email:
-  smtp:
-    from: "journal sender" <journal@example.com>
-    to: "system admin" <admin@example.com>
-```
-
-This will cause journal-brief to use the Python `smtplib` module to send
-the formatted output to `admin@example.com`.
-
-#### Email SMTP configuration keys
-
 * `from`: RFC-5322 format address to be used as the sender address (required)
 
 * `to`: RFC-5322 format address to be used as the recipient address, or a list
@@ -202,18 +173,55 @@ or a list of such addresses
 
 * `subject`: string to be used as the email message subject
 
+* `headers`: dictionary of string keys and string values to be added as
+custom headers; the dictionary cannot include 'From', 'To', 'Cc', or 'Bcc'
+
+Either command-based or SMTP-based delivery must be specified (but not both).
+
+### Email via command
+
+Example:
+```yaml
+email:
+  from: "journal sender" <journal@example.com>
+  to: "system admin" <admin@example.com>
+  command: "sendmail -i -t"
+```
+
+This will cause journal-brief to execute the specified command in a
+child process and pipe the formatted email message to it. The supplied
+command string will be executed via the shell (typically identified in the
+`SHELL` environment variable) so it can make use of shell expansions and
+other features.
+
+### Email via SMTP
+
+Example:
+```yaml
+email:
+  from: "journal sender" <journal@example.com>
+  to: "system admin" <admin@example.com>
+  smtp: {}
+```
+
+This will cause journal-brief to use the Python `smtplib` module to send
+the formatted email message.
+
+Note the usage of YAML 'flow' style to specify an empty mapping for the
+'smtp' configuration, allowing all of the defaults to be used. This is only
+necessary when no SMTP-specific configuration keys are specified.
+
+#### Email SMTP configuration keys
+
 * `host`: hostname or address of the SMTP server to use for sending email
 (defaults to `localhost`)
 
 * `port`: port number to connect to on the SMTP server (defaults to `25`)
 
 * `starttls`: boolean value indicating whether STARTTLS should be used to
-secure the connection to the SMTP server
+secure the connection to the SMTP server (defaults to `false`)
 
 * `user`: username to be used to authenticate to the SMTP server
 
 * `password`: password to be used to authenticate to the SMTP server (only
 used if `user` is specified)
-
-* 'headers': dictionary of string keys and string values to be added as
-custom headers; the dictionary cannot include 'From', 'To', 'Cc', or 'Bcc'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,124 +161,184 @@ exclusions:
             assert len(c['output']) == num_outputs
 
     @pytest.mark.parametrize('badconfig', [
-        {'disallowed': '1'},
-        {'suppress_empty': 'foo'},
-        {'command': []},
-        {'smtp': []},
-        {'command': 'foo', 'smtp': 'bar'},
-        {'smtp': {'disallowed': '1'}},
-        {'smtp': {'from': 'foo'}},
-        {'smtp': {'to': 'bar'}},
-        {'smtp': {
+        {
             'from': 'foo',
             'to': 'bar',
+        },
+        {
+            'from': 'foo',
+            'to': 'bar',
+            'command': 'baz',
+            'disallowed': '1',
+        },
+        {
+            'from': 'foo',
+            'to': 'bar',
+            'command': 'baz',
+            'suppress_empty': 'foo',
+        },
+        {
+            'from': 'foo',
+            'to': 'bar',
+            'command': [],
+        },
+        {
+            'from': 'foo',
+            'to': 'bar',
+            'smtp': [],
+        },
+        {
+            'from': 'foo',
+            'to': 'bar',
+            'command': 'foo',
+            'smtp': 'bar',
+        },
+        {
+            'from': 'foo',
+            'to': 'bar',
+            'smtp': {'disallowed': '1'},
+        },
+        {
+            'from': 'foo',
+            'command': 'baz',
+        },
+        {
+            'to': 'bar',
+            'command': 'baz',
+        },
+        {
+            'from': 'foo',
+            'to': 'bar',
+            'command': 'baz',
             'subject': [],
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
-            'host': [],
-        }},
-        {'smtp': {
+            'smtp': {
+                'host': [],
+            },
+        },
+        {
             'from': 'foo',
             'to': 'bar',
-            'port': [],
-        }},
-        {'smtp': {
+            'smtp': {
+                'port': [],
+            },
+        },
+        {
             'from': 'foo',
             'to': 'bar',
-            'starttls': 'baz',
-        }},
-        {'smtp': {
+            'smtp': {
+                'starttls': 'baz',
+            },
+        },
+        {
             'from': 'foo',
             'to': 'bar',
-            'user': [],
-        }},
-        {'smtp': {
+            'smtp': {
+                'user': [],
+            },
+        },
+        {
             'from': 'foo',
             'to': 'bar',
-            'password': [],
-        }},
-        {'smtp': {
+            'smtp': {
+                'password': [],
+            },
+        },
+        {
             'from': 'foo',
             'to': {},
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'cc': {},
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'bcc': {},
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': [],
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': 'baz',
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'From': 'foo',
             },
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'To': 'foo',
             },
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'Cc': 'foo',
             },
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'Bcc': 'foo',
             },
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'from': 'foo',
             },
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'TO': 'foo',
             },
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'cC': 'foo',
             },
-        }},
-        {'smtp': {
+        },
+        {
             'from': 'foo',
             'to': 'bar',
+            'command': 'baz',
             'headers': {
                 'BcC': 'foo',
             },
-        }},
+        },
     ])
     def test_validation_email(self, badconfig):
         with NamedTemporaryFile(mode='wt') as cfp:
@@ -291,3 +351,26 @@ exclusions:
                     # Test the exception can be represented as a string
                     str(ex)
                     raise
+
+    @pytest.mark.parametrize('oldconfig', [
+        {
+            'command': 'foo',
+        },
+        {
+            'smtp': {
+                'from': 'foo',
+                'to': 'bar',
+                'cc': 'baz',
+                'bcc': 'bat',
+                'subject': 'subj',
+                'headers': {
+                    'blah': 'bluh',
+                },
+            },
+        },
+    ])
+    def test_oldconfig_email(self, oldconfig):
+        with NamedTemporaryFile(mode='wt') as cfp:
+            cfp.write(yaml.dump({'email': oldconfig}))
+            cfp.flush()
+            Config(config_file=cfp.name)


### PR DESCRIPTION
To provide consistency of configuration and output, use MIME-formatted
email for both command-based and SMTP-based delivery modes. This requires
a delivery command which can accept a fully-formatted message as input
(the usual 'mail' and 'sendmail' commands can be used in this way).
