### PR TITLE
Add an example journal-brief@.service file

### DIFF
--- a/conf/journal-brief@.service
+++ b/conf/journal-brief@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run journal-brief with config /etc/journal-brief/%i.yml
+
+[Service]
+ExecStart=journal-brief --conf /etc/journal-brief/%i.yml
+Type=oneshot
+User=root
+Group=systemd-journal
+DynamicUser=True
+# Assume and (enforce) `cursor-file´ to match the config file name
+ReadWritePaths=/var/lib/journal-brief/%i


### PR DESCRIPTION
The paths are according to the Debian package, if you actually want to include this, I can adapt them.

Another issue is that the cursor file has to exist for this to work. Maybe we don't want to be so strict about the cursor file.